### PR TITLE
Add Hover Functionality to Open Gear Modifier Screen

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ mod_name=VHat Can I Roll?
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU LGPL 3.0
 # The mod version. See https://semver.org/
-mod_version=1.11
+mod_version=1.12
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/com/radimous/vhatcaniroll/ClientModEvent.java
+++ b/src/main/java/com/radimous/vhatcaniroll/ClientModEvent.java
@@ -11,5 +11,6 @@ public class ClientModEvent {
     @SubscribeEvent
     public static void onClientSetup(FMLClientSetupEvent event) {
         ClientRegistry.registerKeyBinding(Keybind.OPEN_MOD_SCREEN);
+        ClientRegistry.registerKeyBinding(Keybind.OPEN_MOD_SCREEN_HOVER);
     }
 }

--- a/src/main/java/com/radimous/vhatcaniroll/Config.java
+++ b/src/main/java/com/radimous/vhatcaniroll/Config.java
@@ -24,6 +24,7 @@ public class Config {
     public static final ForgeConfigSpec.BooleanValue SHOW_UNOBTAINABLE_CRAFTED;
     public static final ForgeConfigSpec.BooleanValue DEBUG_UNIQUE_GEAR;
     public static final ForgeConfigSpec.BooleanValue DEBUG_CARDS;
+    public static final ForgeConfigSpec.BooleanValue SHOW_HOVER_TOOLTIP;
     // string instead of enum, because forge would remove enum values that are not present in the enum
     // (this could cause problems if mods are extending the enum - like wold's)
     public static final ForgeConfigSpec.ConfigValue<List<String>> AFFIX_TAG_GROUP_CHANCE_BLACKLIST;
@@ -102,6 +103,10 @@ public class Config {
         SHOW_CARD_CHANCE = builder
             .comment("show card roll chance")
             .define("showCardChance", true);
+
+        SHOW_HOVER_TOOLTIP = builder
+                .comment("show hold [key] to view rolls tooltip")
+                .define("showHoverTooltip", true);
 
         SPEC = builder.build();
     }

--- a/src/main/java/com/radimous/vhatcaniroll/Keybind.java
+++ b/src/main/java/com/radimous/vhatcaniroll/Keybind.java
@@ -147,13 +147,6 @@ public final class Keybind {
                         }
                     }
 
-                    if(tabItem.getItem() instanceof VaultArmorItem vaultArmorItemTab && hoverStack.getItem() instanceof VaultArmorItem vaultArmorItemHover) {
-                        VaultGearType typeTab = vaultArmorItemTab.getGearType(tabItem);
-                        VaultGearType typeHover = vaultArmorItemHover.getGearType(hoverStack);
-                        return typeTab.equals(typeHover);
-                    }
-
-
                     return hoverStack.getItem().equals(tabItem.getItem());
                 })
                 .findFirst()

--- a/src/main/java/com/radimous/vhatcaniroll/Keybind.java
+++ b/src/main/java/com/radimous/vhatcaniroll/Keybind.java
@@ -1,32 +1,205 @@
 package com.radimous.vhatcaniroll;
 
 import com.mojang.blaze3d.platform.InputConstants;
+import com.mojang.datafixers.util.Either;
+import com.radimous.vhatcaniroll.logic.Items;
 import com.radimous.vhatcaniroll.ui.GearModifierScreen;
 
+import iskallia.vault.core.vault.influence.VaultGod;
+import iskallia.vault.gear.VaultGearState;
+import iskallia.vault.gear.data.VaultGearData;
+import iskallia.vault.gear.item.VaultGearItem;
+import iskallia.vault.init.ModGearAttributes;
+import iskallia.vault.item.gear.VaultArmorItem;
+import iskallia.vault.item.gear.VaultCharmItem;
+import iskallia.vault.item.tool.ToolItem;
+import net.minecraft.ChatFormatting;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
+import net.minecraft.network.chat.*;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderTooltipEvent;
 import net.minecraftforge.client.settings.KeyConflictContext;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import org.lwjgl.glfw.GLFW;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import static net.minecraft.util.Mth.hsvToRgb;
 
 @Mod.EventBusSubscriber(modid = VHatCanIRoll.MODID, value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public final class Keybind {
+
+    private static final int HOLD_THRESHOLD = 20;
+    private static final int totalBars = 10;
+
+    private static int holdCounter = 0;
+
+
     @SubscribeEvent
     public static void handleEventInput(TickEvent.ClientTickEvent event) {
         Minecraft mc = Minecraft.getInstance();
         if (mc.player == null || event.phase == TickEvent.Phase.START) {
             return;
         }
-        if (OPEN_MOD_SCREEN.consumeClick()) {
-            mc.setScreen(new GearModifierScreen());
+
+        if(mc.screen != null && OPEN_MOD_SCREEN.isDown()) {
+            holdCounter++;
+            if(holdCounter >= HOLD_THRESHOLD) {
+                openModifierScreen();
+                holdCounter = 0;
+            }
+        }
+        else {
+            holdCounter = 0;
+        }
+
+        if (OPEN_MOD_SCREEN.consumeClick() && mc.screen == null) {
+            openModifierScreen();
         }
     }
+
+    @SubscribeEvent
+    public static void onTooltipRender(RenderTooltipEvent.GatherComponents event) {
+        Minecraft mc = Minecraft.getInstance();
+
+        if (mc.screen == null || !Config.SHOW_HOVER_TOOLTIP.get()) {
+            return;
+        }
+
+        ItemStack hoverStack = event.getItemStack();
+        if (!isValidItem(hoverStack.getItem())) {
+            return;
+        }
+
+        Component tooltip;
+
+        if (isValidItem(hoverStack.getItem())) {
+            if(holdCounter > 0) {
+                double progress = Math.min(1.0, (double) holdCounter / HOLD_THRESHOLD);
+                tooltip = createProgressBar(progress);
+            }
+            else {
+                tooltip = new TranslatableComponent(
+                        "vhatcaniroll.key.hover_tooltip",
+                        new TextComponent("[")
+                                .withStyle(ChatFormatting.GRAY)
+                                .append(new KeybindComponent(OPEN_MOD_SCREEN.getName())
+                                        .copy().withStyle(ChatFormatting.GREEN))
+                                .append("]").withStyle(ChatFormatting.GRAY)
+                ).withStyle(ChatFormatting.DARK_GRAY);
+            }
+
+            event.getTooltipElements().add(Either.left(tooltip));
+        }
+    }
+
+    private static ItemStack getHoveredItem(Screen screen) {
+        if(screen instanceof AbstractContainerScreen<?> containerScreen) {
+            Slot slot = containerScreen.getSlotUnderMouse();
+            if(slot != null) {
+                return slot.getItem();
+            }
+        }
+
+        return ItemStack.EMPTY;
+    }
+
+    private static void openModifierScreen() {
+        Minecraft mc = Minecraft.getInstance();
+
+        if (mc.screen == null) {
+            mc.setScreen(new GearModifierScreen());
+            return;
+        }
+
+        ItemStack hoverStack = getHoveredItem(mc.screen);
+        if (!isValidItem(hoverStack.getItem())) {
+            return;
+        }
+
+        VaultGearData hoverData = VaultGearData.read(hoverStack);
+        Optional<VaultGod> hoverGodCharm = hoverData.getFirstValue(ModGearAttributes.CHARM_VAULT_GOD);
+
+        List<ItemStack> vaultGearItems = Items.getVaultGearItems();
+
+        int targetIndex = IntStream.range(0, vaultGearItems.size())
+                .filter(i -> {
+                    ItemStack tabItem = vaultGearItems.get(i);
+
+                    if(tabItem.getItem() instanceof VaultCharmItem) {
+                        VaultGearData tabData = VaultGearData.read(tabItem);
+                        Optional<VaultGod> tabGodCharm = tabData.getFirstValue(ModGearAttributes.CHARM_VAULT_GOD);
+
+                        if (hoverGodCharm.isPresent() && tabGodCharm.isPresent()) {
+                            return hoverGodCharm.get().equals(tabGodCharm.get());
+                        }
+                    }
+
+                    if(tabItem.getItem() instanceof VaultArmorItem && hoverStack.getItem() instanceof VaultArmorItem) {
+                        return tabItem.getEquipmentSlot() != null && tabItem.getEquipmentSlot().equals(hoverStack.getEquipmentSlot());
+                    }
+
+
+                    return hoverStack.getItem().equals(tabItem.getItem());
+                })
+                .findFirst()
+                .orElse(0);
+
+        GearModifierScreen modifierScreen = GearModifierScreen.openScreenAtIndex(targetIndex);
+
+        if (hoverData.getState() == VaultGearState.IDENTIFIED) {
+            modifierScreen.setLevelInput(hoverData.getItemLevel());
+        }
+
+        mc.setScreen(modifierScreen);
+    }
+
+    private static boolean isValidItem(Item item) {
+        return (item instanceof VaultGearItem && !(item instanceof ToolItem));
+    }
+
+    private static Component createProgressBar(double progress) {
+        int filled = (int) Math.round(progress * totalBars);
+
+        TextComponent bar = new TextComponent("[");
+        bar.setStyle(Style.EMPTY.withColor(ChatFormatting.GRAY));
+
+        for (int i = 0; i < totalBars; i++) {
+            TextComponent segment = new TextComponent("=");
+
+            if (i < filled) {
+                float hue = (float) i / totalBars;
+                int rgb = hsvToRgb(hue, 1.0f, 1.0f); // full saturation and brightness
+                segment.setStyle(Style.EMPTY.withColor(rgb));
+            } else {
+                segment.setStyle(Style.EMPTY.withColor(ChatFormatting.DARK_GRAY));
+            }
+
+            bar.append(segment);
+        }
+
+        bar.append(new TextComponent("=")
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.DARK_GRAY)))
+                .append(new TextComponent("]")
+                        .setStyle(Style.EMPTY.withColor(ChatFormatting.GRAY)));
+
+        return bar;
+    }
+
+
 
 
     public static final String VHAT_CAN_I_ROLL_CATEGORY = "key.categories.vhatcaniroll";
     public static final KeyMapping
-        OPEN_MOD_SCREEN = new KeyMapping("vhatcaniroll.openmodscreen", KeyConflictContext.IN_GAME, InputConstants.UNKNOWN,
-        VHAT_CAN_I_ROLL_CATEGORY);
+        OPEN_MOD_SCREEN = new KeyMapping("vhatcaniroll.openmodscreen", KeyConflictContext.UNIVERSAL, InputConstants.Type.KEYSYM.getOrCreate(GLFW.GLFW_KEY_PAGE_DOWN), VHAT_CAN_I_ROLL_CATEGORY);
 }

--- a/src/main/java/com/radimous/vhatcaniroll/ui/GearModifierScreen.java
+++ b/src/main/java/com/radimous/vhatcaniroll/ui/GearModifierScreen.java
@@ -598,4 +598,14 @@ public class GearModifierScreen extends AbstractElementScreen {
         }
         return 0;
     }
+
+    public static GearModifierScreen openScreenAtIndex(int targetIndex) {
+        GearModifierScreen screen = new GearModifierScreen();
+        screen.switchTab(targetIndex);
+        return screen;
+    }
+
+    public void setLevelInput(int level) {
+        this.lvlInput.setValue(level);
+    }
 }

--- a/src/main/java/com/radimous/vhatcaniroll/ui/GearModifierScreen.java
+++ b/src/main/java/com/radimous/vhatcaniroll/ui/GearModifierScreen.java
@@ -148,7 +148,7 @@ public class GearModifierScreen extends AbstractElementScreen {
 
     }
 
-    private void switchToTransmog(){
+    public void switchToTransmog(){
         this.removeElement(this.innerScreen);
         this.modifierCategory = ModifierCategory.NORMAL;
         updateModifierCategoryButtonLabel();
@@ -161,7 +161,7 @@ public class GearModifierScreen extends AbstractElementScreen {
         ScreenLayout.requestLayout();
     }
 
-    private void switchToModifiers(){
+    public void switchToModifiers(){
         this.removeElement(this.innerScreen);
         ISpatial modListSpatial = Spatials.positionXY(7, 50).size(this.getGuiSpatial().width() - 14, this.getGuiSpatial().height() - 57);
         this.innerScreen = new ModifierListContainer(modListSpatial, lvlInput.getValue(), modifierCategory, getCurrGear(), mythic).layout(this.translateWorldSpatial());
@@ -172,7 +172,7 @@ public class GearModifierScreen extends AbstractElementScreen {
         ScreenLayout.requestLayout();
     }
 
-    private void switchToCrafted(){
+    public void switchToCrafted(){
         this.removeElement(this.innerScreen);
         this.modifierCategory = ModifierCategory.NORMAL;
         updateModifierCategoryButtonLabel();
@@ -185,7 +185,7 @@ public class GearModifierScreen extends AbstractElementScreen {
         ScreenLayout.requestLayout();
     }
 
-    private void switchToUnique(){
+    public void switchToUnique(){
         this.removeElement(this.innerScreen);
         this.modifierCategory = ModifierCategory.NORMAL;
         updateModifierCategoryButtonLabel();

--- a/src/main/resources/assets/vhatcaniroll/lang/en_us.json
+++ b/src/main/resources/assets/vhatcaniroll/lang/en_us.json
@@ -4,6 +4,7 @@
   "vhatcaniroll.screen.title.unique": "Unique Gear",
   "vhatcaniroll.screen.title.transmogs": "Transmogs",
   "vhatcaniroll.openmodscreen": "Open VHat can I roll? screen",
+  "vhatcaniroll.openmodscreen_hover": "Open VHat can I roll? screen (Hover)",
   "key.categories.vhatcaniroll": "VHat can I roll?",
   "vhatcaniroll.key.hover_tooltip": "Hold %s to view rolls"
 }

--- a/src/main/resources/assets/vhatcaniroll/lang/en_us.json
+++ b/src/main/resources/assets/vhatcaniroll/lang/en_us.json
@@ -4,6 +4,7 @@
   "vhatcaniroll.screen.title.unique": "Unique Gear",
   "vhatcaniroll.screen.title.transmogs": "Transmogs",
   "vhatcaniroll.openmodscreen": "Open VHat can I roll? screen",
-  "key.categories.vhatcaniroll": "VHat can I roll?"
+  "key.categories.vhatcaniroll": "VHat can I roll?",
+  "vhatcaniroll.key.hover_tooltip": "Hold %s to view rolls"
 }
 


### PR DESCRIPTION
Adds new functionality when hovering Vault Gear items that lets you hold a newly added keybind (set to W by default like Create uses) to open the Gear Modifier screen to the correct gear piece and level. 

Works for variations of the same type of item like the Vault God Charms and Armor items. 

When using this functionality on a unique, it will open up the page for uniques instead of the normal modifiers.

A config option has been added to disable the tooltip from displaying.

Figured this may make the mod more visible for players and is a handy tool to quickly access the right page when working on gear.

Some missing functionality I could think of is opening the right tier for Vault Maps, but I didn't feel like dipping into reflection to accomplish this similar to how the rest of the mod does it right now. This is all the original functionality I wanted to accomplish though.

<img width="400" height="194" alt="Screenshot From 2025-11-04 09-04-02" src="https://github.com/user-attachments/assets/bd41677a-eed4-49d0-88da-6731275da2be" />
<img width="400" height="194" alt="Screenshot From 2025-11-04 09-04-13" src="https://github.com/user-attachments/assets/c30b430d-c2c6-4127-98b8-b793593b4998" />
